### PR TITLE
Document that page cound cannot be higher than u16::MAX

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,8 @@ pub const PAGE_SIZE: usize = raw::PAGE_SIZE;
 /// This value is just a compile-time upper limit, used to size some in-memory and on-disk data
 /// structures. This allows supporting different memory sizes with the same binary.
 ///
+/// The [`PageID`](crate::types::PageID) is backed by a `u16` so the maximum page count is 65535.
+///
 /// Default: 256
 pub const MAX_PAGE_COUNT: usize = raw::MAX_PAGE_COUNT;
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -17,6 +17,8 @@ pub trait Flash {
     type Error: Debug;
 
     /// Get the page count of the flash storage.
+    ///
+    /// The [`PageID`](crate::types::PageID) is backed by a `u16` so the maximum page count is 65535.
     fn page_count(&self) -> usize;
 
     /// Erase a page.


### PR DESCRIPTION
I ran into this limit when trying to use this crate on an SD card with 512 byte blocks.

I considered making a PR to make the type backing the `PageID` configurable but the linear scan of the flash when mounting the database is prohibitively slow so letting ekv manage the whole flash is probably not a good idea.