### PR TITLE
Support 8 byte and 16 byte alignment with compact chunk header

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfontconfig1-dev
       - name: test
         run: |
           ./ci.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ _test = []
 align-1 = []
 align-2 = []
 align-4 = [] # Default
+align-8 = []
+align-16 = []
 
 page-size-128 = []
 page-size-256 = []

--- a/build.rs
+++ b/build.rs
@@ -89,6 +89,18 @@ fn main() {
         }
     }
 
+    // Check for conflicting align features
+    let align_features: Vec<_> = ["CARGO_FEATURE_ALIGN_1", "CARGO_FEATURE_ALIGN_2",
+                                   "CARGO_FEATURE_ALIGN_4", "CARGO_FEATURE_ALIGN_8",
+                                   "CARGO_FEATURE_ALIGN_16"]
+        .iter()
+        .filter(|f| env::var(f).is_ok())
+        .collect();
+
+    if align_features.len() > 1 {
+        panic!("Multiple align features enabled: {:?}", align_features);
+    }
+
     let mut data = String::new();
 
     for (name, cfg) in &configs {

--- a/build.rs
+++ b/build.rs
@@ -90,12 +90,16 @@ fn main() {
     }
 
     // Check for conflicting align features
-    let align_features: Vec<_> = ["CARGO_FEATURE_ALIGN_1", "CARGO_FEATURE_ALIGN_2",
-                                   "CARGO_FEATURE_ALIGN_4", "CARGO_FEATURE_ALIGN_8",
-                                   "CARGO_FEATURE_ALIGN_16"]
-        .iter()
-        .filter(|f| env::var(f).is_ok())
-        .collect();
+    let align_features: Vec<_> = [
+        "CARGO_FEATURE_ALIGN_1",
+        "CARGO_FEATURE_ALIGN_2",
+        "CARGO_FEATURE_ALIGN_4",
+        "CARGO_FEATURE_ALIGN_8",
+        "CARGO_FEATURE_ALIGN_16",
+    ]
+    .iter()
+    .filter(|f| env::var(f).is_ok())
+    .collect();
 
     if align_features.len() > 1 {
         panic!("Multiple align features enabled: {:?}", align_features);

--- a/ci.sh
+++ b/ci.sh
@@ -12,6 +12,8 @@ FEATURESET=(
     ekv/page-size-256,ekv/max-page-count-64,ekv/max-value-size-128,ekv/scratch-page-count-4,ekv/align-1
     ekv/page-size-256,ekv/max-page-count-256,ekv/max-value-size-1024,ekv/scratch-page-count-8,ekv/align-2
     ekv/page-size-256,ekv/max-page-count-256,ekv/max-value-size-1024,ekv/scratch-page-count-8,ekv/align-4
+    ekv/page-size-256,ekv/max-page-count-256,ekv/max-value-size-1024,ekv/scratch-page-count-8,ekv/align-8
+    ekv/page-size-256,ekv/max-page-count-256,ekv/max-value-size-1024,ekv/scratch-page-count-8,ekv/align-16
     ekv/page-size-4096,ekv/max-page-count-256,ekv/max-chunk-size-512,ekv/max-value-size-1024,ekv/scratch-page-count-4,ekv/crc,ekv/align-4
     ekv/page-size-1024,ekv/max-page-count-16,ekv/max-value-size-16,ekv/scratch-page-count-0
     ekv/page-size-128,ekv/max-page-count-32,ekv/max-value-size-16,ekv/scratch-page-count-0

--- a/gen_config.py
+++ b/gen_config.py
@@ -35,7 +35,7 @@ def feature(name, default, min=None, max=None, pow2=None, vals=None, factors=[])
     )
 
 
-feature("align", default=4, vals=[1, 2, 4])
+feature("align", default=4, vals=[1, 2, 4, 8, 16])
 feature("page_size", default=4096, min=128, max=65536, pow2=True)
 feature("max_page_count", default=256, min=1,
         max=65536, pow2=True, factors=[3, 5, 9])

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@
 use core::mem::size_of;
 
 use crate::file::{DataHeader, MetaHeader, PAGE_MAX_PAYLOAD_SIZE};
+use crate::page::{ChunkHeader, PageHeader};
 use crate::record::RecordHeader;
 
 mod raw {
@@ -200,10 +201,17 @@ const _CHECKS: () = {
 
     core::assert!(BRANCHING_FACTOR >= 2 && BRANCHING_FACTOR <= 4);
 
-    // Only align 1, 2, 4 is supported for now.
-    // We only align data. Header sizes are aligned to 4 but not 8.
-    // Supporting higher aligns would require aligning the headers as well.
-    core::assert!(ALIGN == 1 || ALIGN == 2 || ALIGN == 4);
+    // Support align 1, 2, 4, 8, 16
+    core::assert!(ALIGN == 1 || ALIGN == 2 || ALIGN == 4 || ALIGN == 8 || ALIGN == 16);
+
+    // Verify headers are properly aligned
+    core::assert!(size_of::<PageHeader>() % ALIGN == 0, "PageHeader not aligned to ALIGN");
+    core::assert!(
+        size_of::<ChunkHeader>() % ALIGN == 0,
+        "ChunkHeader not aligned to ALIGN"
+    );
+    core::assert!(size_of::<MetaHeader>() % ALIGN == 0, "MetaHeader not aligned to ALIGN");
+    core::assert!(size_of::<DataHeader>() % ALIGN == 0, "DataHeader not aligned to ALIGN");
 
     // assert MIN_FREE_PAGE_COUNT is reasonable.
     // If it's too big relative to the total flash size, we'll waste a lot of space!

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@
 use core::mem::size_of;
 
 use crate::file::{DataHeader, MetaHeader, PAGE_MAX_PAYLOAD_SIZE};
-use crate::page::{ChunkHeader, PageHeader};
+use crate::page::PageHeader;
 use crate::record::RecordHeader;
 
 mod raw {
@@ -53,7 +53,7 @@ pub const CRC: bool = raw::CRC;
 /// multiples of this value. Useful when the flash supports writing with 16-bit
 /// or 32-bit word granularity.
 ///
-/// Supported values: 1, 2 or 4.
+/// Supported values: 1, 2, 4, 8 or 16.
 ///
 /// Default: 4
 pub const ALIGN: usize = raw::ALIGN;
@@ -206,10 +206,7 @@ const _CHECKS: () = {
 
     // Verify headers are properly aligned
     core::assert!(size_of::<PageHeader>() % ALIGN == 0, "PageHeader not aligned to ALIGN");
-    core::assert!(
-        size_of::<ChunkHeader>() % ALIGN == 0,
-        "ChunkHeader not aligned to ALIGN"
-    );
+    // Note: ChunkHeader no longer needs to be aligned because it's packed with data
     core::assert!(size_of::<MetaHeader>() % ALIGN == 0, "MetaHeader not aligned to ALIGN");
     core::assert!(size_of::<DataHeader>() % ALIGN == 0, "DataHeader not aligned to ALIGN");
 


### PR DESCRIPTION
* Support 8 and 16 byte alignment for headers
* Chunk header + first part of data is now written together to reduce unnecessary padding for chunks.