### PR TITLE
cap chunk data so on-flash footprint == MAX_CHUNK_SIZE   

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -15,6 +15,7 @@ FEATURESET=(
     ekv/page-size-256,ekv/max-page-count-256,ekv/max-value-size-1024,ekv/scratch-page-count-8,ekv/align-8
     ekv/page-size-256,ekv/max-page-count-256,ekv/max-value-size-1024,ekv/scratch-page-count-8,ekv/align-16
     ekv/page-size-4096,ekv/max-page-count-256,ekv/max-chunk-size-512,ekv/max-value-size-1024,ekv/scratch-page-count-4,ekv/crc,ekv/align-4
+    ekv/page-size-4096,ekv/max-page-count-256,ekv/max-chunk-size-512,ekv/max-value-size-1024,ekv/scratch-page-count-4,ekv/crc,ekv/align-16
     ekv/page-size-1024,ekv/max-page-count-16,ekv/max-value-size-16,ekv/scratch-page-count-0
     ekv/page-size-128,ekv/max-page-count-32,ekv/max-value-size-16,ekv/scratch-page-count-0
     ekv/page-size-128,ekv/max-page-count-32,ekv/max-value-size-16,ekv/scratch-page-count-0,ekv/crc

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,11 @@ pub const ERASE_VALUE: u8 = match raw::ERASE_VALUE {
 /// The chunk size controls how big chunks of data is read and written from/to flash. A low
 /// value reduces the memory usage of EKV at the expense of more reads/writes.
 ///
+/// This is the maximum number of *data* bytes per chunk. The on-flash footprint of a chunk
+/// is `align_up(ChunkHeader::SIZE + data_len)`, so when `ALIGN > ChunkHeader::SIZE` a full
+/// chunk occupies more than `MAX_CHUNK_SIZE` bytes on flash (exactly
+/// `MAX_CHUNK_SIZE + align_up(ChunkHeader::SIZE)`).
+///
 /// Default: 4096
 pub const MAX_CHUNK_SIZE: usize = raw::MAX_CHUNK_SIZE;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,9 +97,9 @@ pub const ERASE_VALUE: u8 = match raw::ERASE_VALUE {
 /// value reduces the memory usage of EKV at the expense of more reads/writes.
 ///
 /// This is the maximum number of *data* bytes per chunk. The on-flash footprint of a chunk
-/// is `align_up(ChunkHeader::SIZE + data_len)`, so when `ALIGN > ChunkHeader::SIZE` a full
-/// chunk occupies more than `MAX_CHUNK_SIZE` bytes on flash (exactly
-/// `MAX_CHUNK_SIZE + align_up(ChunkHeader::SIZE)`).
+/// occupies more space on flash due to the chunk header which also needs to be aligned.
+///
+/// The total amount of space consumed on flash is `align_up(ChunkHeader::SIZE + data_len)`.
 ///
 /// Default: 4096
 pub const MAX_CHUNK_SIZE: usize = raw::MAX_CHUNK_SIZE;

--- a/src/page.rs
+++ b/src/page.rs
@@ -856,6 +856,51 @@ mod tests {
         assert_eq!(data, buf);
     }
 
+    // Regression test for a buffer overflow in PageReader::load_chunk that fired when
+    // ALIGN > ChunkHeader::SIZE (so header padding overlays initial data bytes) and a
+    // chunk was written all the way up to MAX_CHUNK_SIZE.
+    //
+    // The writer's is_chunk_full() let chunk_pos reach MAX_CHUNK_SIZE, producing an
+    // auto-committed chunk with len == MAX_CHUNK_SIZE. On read, load_chunk tries to
+    // write `data_in_first_block + align_up(chunk_len - data_in_first_block)` bytes into
+    // `buf: [u8; MAX_CHUNK_SIZE]`. With align-16 + crc + max-chunk-size-512 that's
+    // `8 + align_up(504) = 520` bytes into a 512-byte buffer → panic.
+    #[test_log::test(tokio::test)]
+    #[cfg(all(feature = "align-16", feature = "crc", feature = "max-chunk-size-512"))]
+    async fn test_chunk_fills_to_max_chunk_size_no_buf_overflow() {
+        let f = &mut MemFlash::new();
+        let data = dummy_data(MAX_CHUNK_SIZE);
+
+        let mut w: PageWriter<TestHeader> = PageWriter::new();
+        w.open(f, PAGE).await;
+        let mut written = 0;
+        while written < data.len() {
+            let n = w.write(f, &data[written..]).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            written += n;
+        }
+        assert_eq!(written, data.len());
+        w.write_header(f, HEADER).await.unwrap();
+        w.commit(f).await.unwrap();
+
+        let mut r = PageReader::new();
+        let h = r.open::<_, TestHeader>(f, PAGE).await.unwrap();
+        assert_eq!(h, HEADER);
+        let mut buf = vec![0u8; data.len()];
+        let mut total = 0;
+        loop {
+            let n = r.read(f, &mut buf[total..]).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            total += n;
+        }
+        assert_eq!(total, data.len());
+        assert_eq!(buf, data);
+    }
+
     #[test_log::test(tokio::test)]
     async fn test_overread() {
         let f = &mut MemFlash::new();
@@ -899,7 +944,15 @@ mod tests {
             writes += 1;
         }
 
-        let expected = PAGE_SIZE - PageHeader::SIZE - size_of::<TestHeader>() - (ChunkHeader::SIZE * writes);
+        // Per-chunk flash footprint is align_up(ChunkHeader::SIZE + chunk_data);
+        // the alignment padding is overhead beyond the chunk header itself when
+        // ALIGN > ChunkHeader::SIZE. All but the last chunk are filled to MAX_CHUNK_SIZE.
+        const FULL_CHUNK_OVERHEAD: usize = align_up(ChunkHeader::SIZE + MAX_CHUNK_SIZE) - MAX_CHUNK_SIZE;
+        let expected = PAGE_SIZE
+            - PageHeader::SIZE
+            - size_of::<TestHeader>()
+            - FULL_CHUNK_OVERHEAD * (writes - 1)
+            - ChunkHeader::SIZE;
         assert_eq!(total, expected, "writes: {}", writes);
         w.write_header(f, HEADER).await.unwrap();
         w.commit(f).await.unwrap();

--- a/src/page.rs
+++ b/src/page.rs
@@ -86,6 +86,17 @@ pub(crate) const MAX_CHUNK_SIZE: usize = if config::MAX_CHUNK_SIZE > (PAGE_SIZE 
     config::MAX_CHUNK_SIZE
 };
 
+/// Size of PageReader's chunk buffer.
+///
+/// A chunk's on-flash footprint is `align_up(ChunkHeader::SIZE + data_len)`
+/// (header + data + trailing alignment padding). load_chunk parses the header
+/// into a stack-local, so the in-memory buffer holds everything except the
+/// header — hence `footprint - ChunkHeader::SIZE`.
+///
+/// When ALIGN > ChunkHeader::SIZE this exceeds MAX_CHUNK_SIZE by up to
+/// ALIGN - ChunkHeader::SIZE bytes.
+const READ_BUF_SIZE: usize = align_up(ChunkHeader::SIZE + MAX_CHUNK_SIZE) - ChunkHeader::SIZE;
+
 async fn write_header<F: Flash, H: Header>(flash: &mut F, page_id: PageID, header: H) -> Result<(), F::Error> {
     assert!(size_of::<H>() <= MAX_HEADER_SIZE);
     let mut buf = [0u8; PageHeader::SIZE + MAX_HEADER_SIZE];
@@ -216,7 +227,9 @@ pub struct PageReader {
     chunk_pos: usize,
 
     /// Data in the current chunk.
-    buf: [u8; MAX_CHUNK_SIZE],
+    ///
+    /// Sized to fit load_chunk's worst-case aligned read, not MAX_CHUNK_SIZE.
+    buf: [u8; READ_BUF_SIZE],
 }
 
 #[derive(Clone)]
@@ -238,7 +251,7 @@ impl PageReader {
                 chunk_crc: 0,
             },
             chunk_pos: 0,
-            buf: [0u8; MAX_CHUNK_SIZE],
+            buf: [0u8; READ_BUF_SIZE],
         }
     }
 


### PR DESCRIPTION
With `ALIGN > ChunkHeader::SIZE`, the writer could produce a chunk whose data length made `PageReader::load_chunk` overflow its `MAX_CHUNK_SIZE`-sized buffer.

Breaks chunks with `len > MAX_CHUNK_DATA_SIZE` (rejected as Corrupted and need re-formatting).

The alternative fix is to fix the read path, but forcing header + data to fit within the configured max-chunk-size seems better in terms of predictable flash usage?